### PR TITLE
Directory walk routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 * Added `walkDir` function to traverse a directory tree with a handler.
 
-* Added `walkDirAccum` function which is like `walkDir` but also accumulates
-  the output of the handler and returns it.
+* Added `walkDirAccum` function which is like `walkDir` but also accepts an
+  output writer and returns the accumulated output.
 
 * Added `listDirRecurWith` function which is like `listDirRecur` but with
   predicates to select directories and files.
 
 * Added `listDirRecurWithPruned` function which is like `listDirRecurWith` but
   does not traverse the selected directories further.
+
+* All recursive traversal functions (existing and new) now safely handle
+  directory loops due to symbolic or hard links.
 
 ## Path IO 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Path IO 1.2.0
+
+* Added `walkDir` function to traverse a directory tree with a handler.
+
+* Added `walkDirAccum` function which is like `walkDir` but also accumulates
+  the output of the handler and returns it.
+
+* Added `listDirRecurWith` function which is like `listDirRecur` but with
+  predicates to select directories and files.
+
+* Added `listDirRecurWithPruned` function which is like `listDirRecurWith` but
+  does not traverse the selected directories further.
+
 ## Path IO 1.1.0
 
 * Fixed bug in `copyDirRecur` when it was unable to fully copy read-only

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -117,7 +117,7 @@ import qualified System.FilePath  as F
 import qualified System.IO.Temp   as T
 
 #if !MIN_VERSION_base(4,8,0)
-import Data.Monoid (mappend)
+import Data.Monoid (Monoid)
 #endif
 
 ----------------------------------------------------------------------------

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -403,9 +403,7 @@ walkDir
   -> Path b Dir
      -- ^ Directory where traversal begins
   -> m ()
-walkDir handler topdir = do
-  _ <- makeAbsolute topdir >>= walkAvoidLoop Set.empty
-  return ()
+walkDir handler topdir = void (makeAbsolute topdir >>= walkAvoidLoop Set.empty)
   where
     walkAvoidLoop traversed curdir = do
       mRes <- checkLoop traversed curdir

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -403,9 +403,8 @@ walkDir
   -> Path b Dir
      -- ^ Directory where traversal begins
   -> m ()
-walkDir handler topdir = do
-  _ <- makeAbsolute topdir >>= walkAvoidLoop Set.empty
-  return ()
+walkDir handler topdir =
+  makeAbsolute topdir >>= walkAvoidLoop Set.empty >> return ()
   where
     walkAvoidLoop traversed curdir = do
       mRes <- checkLoop traversed curdir

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -444,7 +444,7 @@ walkDir handler topdir =
 -- | Create a descend handler for `walkDir` which excludes sub-directories
 -- matching a predicate, from descending.
 
-descendExcluding :: (MonadIO m, MonadThrow m)
+descendExcluding :: MonadIO m
   => (Path Abs Dir -> m Bool)
      -- ^ Directory match predicate
   -> (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> m WalkAction)
@@ -455,7 +455,11 @@ descendExcluding p = handler
 -- | Create a descend handler for `walkDir` which descends only sub-directories
 -- matching a predicate.
 
-descendWith :: (MonadIO m, MonadThrow m)
+descendWith :: (MonadIO m
+#if !MIN_VERSION_base(4,8,0)
+  , Functor m
+#endif
+  )
   => (Path Abs Dir -> m Bool)
      -- ^ Directory match predicate
   -> (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File] -> m WalkAction)
@@ -466,6 +470,10 @@ descendWith p = handler
 -- | Similar to 'walkDir' but accepts a 'Monoid' returning, output
 -- writer as well. Values returned by the output writer invocations are
 -- accumulated and returned.
+--
+-- Both, the descend handler as well as the output writer can be used for side
+-- effects but keep in mind that the output writer runs before the descend
+-- handler.
 
 walkDirAccum
   :: (MonadIO m, MonadThrow m, Monoid o)
@@ -492,7 +500,7 @@ walkDirAccum dHandler writer topdir = do
 -- | Create an output writer for `walkDirAccum` which writes dirs and
 -- files matching corresponding predicates, as a tuple of lists.
 
-writeWith :: (MonadIO m, MonadThrow m)
+writeWith :: MonadIO m
   => (Path Abs Dir -> m Bool)                 -- ^ Directory match predicate
   -> (Path Abs File -> m Bool)                -- ^ File match predicate
   -> (Path Abs Dir -> [Path Abs Dir] -> [Path Abs File]

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -403,7 +403,9 @@ walkDir
   -> Path b Dir
      -- ^ Directory where traversal begins
   -> m ()
-walkDir handler topdir = void (makeAbsolute topdir >>= walkAvoidLoop Set.empty)
+walkDir handler topdir = do
+  _ <- makeAbsolute topdir >>= walkAvoidLoop Set.empty
+  return ()
   where
     walkAvoidLoop traversed curdir = do
       mRes <- checkLoop traversed curdir

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -103,7 +103,6 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Control.Monad.Trans.Writer.Lazy (runWriterT, tell)
 import Data.Either (lefts, rights)
-import Data.Foldable (foldl')
 import Data.List ((\\))
 import Data.Time (UTCTime)
 import Path
@@ -327,9 +326,8 @@ listDir path = do
 listDirRecur :: (MonadIO m, MonadThrow m)
   => Path b Dir        -- ^ Directory to list
   -> m ([Path Abs Dir], [Path Abs File]) -- ^ Sub-directories and files
-listDirRecur path = do
-  items <- listDir path
-  foldl' mappend items `liftM` mapM listDirRecur (fst items)
+listDirRecur path = walkDirAll' handler path
+  where handler _ dirs files = return (dirs, files)
 
 -- Recursive directory walk functionality, with a flexible API and avoidance
 -- of loops. Following are some notes on the design.

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -28,6 +28,7 @@ module Path.IO
   , WalkHandler
   , walkDir
   , walkDir'
+  , walkDirAll
   , listDir
   , listDirRecur
   , copyDirRecur
@@ -426,6 +427,20 @@ walkDir' handler topdir = do
       (act, res) <- lift $ handler dir subdirs files
       tell res
       return act
+
+-- | Similar to 'walkDir' but with a simpler handler which does not control the
+-- traversal, it just walks the entire tree.
+walkDirAll
+  :: (MonadIO m, MonadThrow m)
+  => WalkHandler m ()
+     -- ^ Handler called at each directory traversed
+  -> Path b Dir
+     -- ^ Directory where the traversal begins
+  -> m ()
+walkDirAll handler = walkDir handler'
+  where handler' dir subdirs files = do
+          handler dir subdirs files
+          return (WalkDescend subdirs)
 
 -- | Copy directory recursively. This is not smart about symbolic links, but
 -- tries to preserve permissions when possible. If destination directory

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -341,7 +341,7 @@ listDirRecurWith dirPred filePred = walkDirAccum handler
   where handler _ dirs files = do
           d <- filterM dirPred dirs
           f <- filterM filePred files
-          return (WalkDescend d, (d, f))
+          return (WalkDescend dirs, (d, f))
 
 -- | Similar to 'listDirRecurWith' but prunes the matched directories
 -- i.e. it returns the matched dirs but does not traverse them.

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -82,6 +82,7 @@ test-suite tests
                     , hspec        >= 2.0     && < 3.0
                     , path         >= 0.5     && < 0.6
                     , path-io      >= 1.1.0
+                    , unix-compat
   default-language:   Haskell2010
 
 source-repository head

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -53,6 +53,7 @@ flag dev
 
 library
   build-depends:      base         >= 4.7     && < 5.0
+                    , containers
                     , directory    >= 1.2.2.0 && < 1.3
                     , exceptions   >= 0.8     && < 0.9
                     , filepath     >= 1.2     && < 1.5
@@ -60,6 +61,7 @@ library
                     , temporary    >= 1.1     && < 1.3
                     , time         >= 1.4     && < 1.7
                     , transformers >= 0.3     && < 0.6
+                    , unix-compat
   exposed-modules:    Path.IO
   if flag(dev)
     ghc-options:      -Wall -Werror

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -112,7 +112,7 @@ walkDirFinishSpec =
     map dirname d `shouldContain` [$(mkRelDir "c")]
     where handler p dirs files
             | dirname p == $(mkRelDir "c") = return (WalkFinish, ([],[]))
-            | otherwise = return (WalkDescend dirs, (dirs, files))
+            | otherwise = return (WalkExclude [], (dirs, files))
 
 copyDirRecurSpec :: SpecWith (Path Abs Dir)
 copyDirRecurSpec = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -108,7 +108,7 @@ listDirRecurCyclicSpec =
 walkDirFinishSpec :: SpecWith (Path Abs Dir)
 walkDirFinishSpec =
   it "Finishes only after finding what it is looking for" $ \dir -> do
-      (d, _) <- getDirStructure (walkDirAccum (Just dHandler) writer) dir
+    (d, _) <- getDirStructure (walkDirAccum (Just dHandler) writer) dir
     map dirname d `shouldContain` [$(mkRelDir "c")]
     where dHandler p _ _
             | dirname p == $(mkRelDir "c") = return WalkFinish

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -108,11 +108,13 @@ listDirRecurCyclicSpec =
 walkDirFinishSpec :: SpecWith (Path Abs Dir)
 walkDirFinishSpec =
   it "Finishes only after finding what it is looking for" $ \dir -> do
-    (d, _) <- getDirStructure (walkDirAccum handler) dir
+      (d, _) <- getDirStructure (walkDirAccum (Just dHandler) writer) dir
     map dirname d `shouldContain` [$(mkRelDir "c")]
-    where handler p dirs files
-            | dirname p == $(mkRelDir "c") = return (WalkFinish, ([],[]))
-            | otherwise = return (WalkExclude [], (dirs, files))
+    where dHandler p _ _
+            | dirname p == $(mkRelDir "c") = return WalkFinish
+            | otherwise = return (WalkExclude [])
+
+          writer _ d f = return (d, f)
 
 copyDirRecurSpec :: SpecWith (Path Abs Dir)
 copyDirRecurSpec = do


### PR DESCRIPTION
I added a generic directory walk functionality which walks a dir tree and calls a handler during traversal. All other variants of dir recurse functionality can be implemented in terms of this one core function. It also avoids loops in traversal due to symlinks or hardlinks.

It may be better to review one commit at a time. First of all, please take a look if the APIs, naming etc. looks ok or if you have any better suggestions.

I also added a few more `listDirRecur` variants, if you think those are a bloat I am fine to leave them out.