### PR TITLE
Add support for XDG directories

### DIFF
--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -41,6 +41,10 @@ module Path.IO
   , getAppUserDataDir
   , getUserDocsDir
   , getTempDir
+#if MIN_VERSION_directory(1,2,3)
+  , getXdgDir
+  , XdgDirectory(..)
+#endif
     -- * Path transformation
   , AbsPath
   , RelPath
@@ -107,6 +111,9 @@ import Path
 import System.IO (Handle)
 import System.IO.Error (isDoesNotExistError)
 import System.PosixCompat.Files (deviceID, fileID, getFileStatus)
+#if MIN_VERSION_directory(1,2,3)
+import System.Directory (XdgDirectory)
+#endif
 import qualified Data.Set         as S
 import qualified System.Directory as D
 import qualified System.FilePath  as F
@@ -699,6 +706,26 @@ getUserDocsDir = liftIO D.getUserDocumentsDirectory >>= parseAbsDir
 getTempDir :: (MonadIO m, MonadThrow m) => m (Path Abs Dir)
 getTempDir = liftIO D.getTemporaryDirectory >>= resolveDir'
 {-# INLINE getTempDir #-}
+
+#if MIN_VERSION_directory(1,2,3)
+-- | Obtain the paths to special directories for storing user-specific
+--   application data, configuration, and cache files, conforming to the
+--   <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html XDG Base Directory Specification>.
+--   Compared with 'getAppUserDataDir', this function provides a more
+--   fine-grained hierarchy as well as greater flexibility for the user.
+--
+-- It also works on Windows, although in that case 'XdgData' and 'XdgConfig'
+-- will map to the same directory.
+--
+-- The second argument is usually a path based on the name of the application.
+-- If it is 'Nothing', only the base path is returned.
+--
+-- Note: The directory may not actually exist, in which case you would need
+-- to create it with file mode @700@ (i.e. only accessible by the owner).
+getXdgDir :: (MonadIO m, MonadThrow m) => XdgDirectory -> Maybe (Path Rel Dir) -> m (Path Abs Dir)
+getXdgDir xdgDir suffix = liftIO (D.getXdgDirectory xdgDir $ maybe "" toFilePath suffix) >>= parseAbsDir
+{-# INLINE getXdgDir #-}
+#endif
 
 ----------------------------------------------------------------------------
 -- Path transformation

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -64,11 +64,16 @@ main = hspec . around withSandbox $ do
   beforeWith populatedCyclicDir $
     describe "listDirRecur Cyclic" listDirRecurCyclicSpec
 #endif
-  describe "getCurrentDir"  getCurrentDirSpec
-  describe "setCurrentDir"  setCurrentDirSpec
-  describe "withCurrentDir" withCurrentDirSpec
-  describe "getHomeDir"     getHomeDirSpec
-  describe "getTempDir"     getTempDirSpec
+  describe "getCurrentDir"    getCurrentDirSpec
+  describe "setCurrentDir"    setCurrentDirSpec
+  describe "withCurrentDir"   withCurrentDirSpec
+  describe "getHomeDir"       getHomeDirSpec
+  describe "getTempDir"       getTempDirSpec
+#if MIN_VERSION_directory(1,2,3)
+  describe "getXdgDir Data"   getXdgDataDirSpec
+  describe "getXdgDir Config" getXdgConfigDirSpec
+  describe "getXdgDir Cache"  getXdgCacheDirSpec
+#endif
 
 listDirSpec :: SpecWith (Path Abs Dir)
 listDirSpec = it "lists directory" $ \dir ->
@@ -191,6 +196,41 @@ getTempDirSpec =
       getTempDir `shouldReturn` dir
       unsetEnv evar
   where evar = "TMPDIR"
+
+#if MIN_VERSION_directory(1,2,3)
+getXdgDataDirSpec :: SpecWith (Path Abs Dir)
+getXdgDataDirSpec =
+  it "XDG data dir is influenced by environment variable XDG_DATA_HOME" $ \dir ->
+    flip finally (unsetEnv evar) $ do
+      setEnv evar (toFilePath dir)
+      getXdgDir XdgData (Just name) `shouldReturn` (dir </> name)
+      getXdgDir XdgData Nothing `shouldReturn` dir
+      unsetEnv evar
+  where evar = "XDG_DATA_HOME"
+        name = $(mkRelDir "test")
+
+getXdgConfigDirSpec :: SpecWith (Path Abs Dir)
+getXdgConfigDirSpec =
+  it "XDG config dir is influenced by environment variable XDG_CONFIG_HOME" $ \dir ->
+    flip finally (unsetEnv evar) $ do
+      setEnv evar (toFilePath dir)
+      getXdgDir XdgConfig (Just name) `shouldReturn` (dir </> name)
+      getXdgDir XdgConfig Nothing `shouldReturn` dir
+      unsetEnv evar
+  where evar = "XDG_CONFIG_HOME"
+        name = $(mkRelDir "test")
+
+getXdgCacheDirSpec :: SpecWith (Path Abs Dir)
+getXdgCacheDirSpec =
+  it "XDG cache dir is influenced by environment variable XDG_CACHE_HOME" $ \dir ->
+    flip finally (unsetEnv evar) $ do
+      setEnv evar (toFilePath dir)
+      getXdgDir XdgCache (Just name) `shouldReturn` (dir </> name)
+      getXdgDir XdgCache Nothing `shouldReturn` dir
+      unsetEnv evar
+  where evar = "XDG_CACHE_HOME"
+        name = $(mkRelDir "test")
+#endif
 
 ----------------------------------------------------------------------------
 -- Helpers


### PR DESCRIPTION
Compared to `directory`, this exports two different functions for getting the base (`System.Directory.getXdgDirectory` with empty suffix) and with a sub-directory under the XDG directory.

One alternative solution would be to use `Maybe (Path Rel Dir)` as the second argument to `getXdgDir`. What do you think?