### PR TITLE
path-io.cabal: allow time-1.8, comes with ghc-8.2.1_rc1

### DIFF
--- a/path-io.cabal
+++ b/path-io.cabal
@@ -60,7 +60,7 @@ library
                     , filepath     >= 1.2     && < 1.5
                     , path         >= 0.5     && < 0.6
                     , temporary    >= 1.1     && < 1.3
-                    , time         >= 1.4     && < 1.8
+                    , time         >= 1.4     && < 1.9
                     , transformers >= 0.3     && < 0.6
                     , unix-compat
   exposed-modules:    Path.IO


### PR DESCRIPTION
Reported-by: Donat Kh
Bug: https://github.com/gentoo-haskell/gentoo-haskell/issues/612
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>