### PR TITLE
Change the default behavior of APIs to not follow symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Path IO 1.3.0
 
+* Add `isSymLink` API to test whether a path is symbolic link
+
 * Change the default behavior of recursive traversal APIs to not follow
   symbolic links
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Path IO 1.3.0
 
+* Change the default behavior of recursive traversal APIs to not follow
+  symbolic links
+
 * Move the type functions `AbsPath` and `RelPath` to the `AnyPath` type
   class.
 

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -51,6 +51,7 @@ test-suite tests
                     , hspec        >= 2.0     && < 3.0
                     , path         >= 0.5     && < 0.6
                     , path-io
+                    , transformers >= 0.3     && < 0.6
                     , unix-compat
   default-language:   Haskell2010
 


### PR DESCRIPTION
I have not tested this on Windows, as I do not have a windows setup. Could you please build and test for windows? 

Fixes #12 