### PR TITLE
Speed up recursive directory listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Path IO 1.3.1
+
+* Made `listDirRecur` faster for deep directory trees.
+
 ## Path IO 1.3.0
 
 * Change the default behavior of recursive traversal APIs to not follow

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -24,6 +24,7 @@ library
   build-depends:      base         >= 4.7     && < 5.0
                     , containers
                     , directory    >= 1.2.2   && < 1.4
+                    , dlist        >= 0.8     && < 0.9
                     , exceptions   >= 0.8     && < 0.9
                     , filepath     >= 1.2     && < 1.5
                     , path         >= 0.5     && < 0.6


### PR DESCRIPTION
@harendra-kumar We should have used difference lists here because linked lists are poor performing monoids :-)