### PR TITLE
Reduce constraints to MonadIO where possible #27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Path IO 1.3.2
+
+* Reduce a number of `(MonadIO m, MonadThrow m)` constraints to just
+  `MonadIO m` [#27](https://github.com/mrkkrp/path-io/issues/27)
+
 ## Path IO 1.3.1
 
 * Made `listDirRecur` faster for deep directory trees.

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -1,5 +1,5 @@
 name:                 path-io
-version:              1.3.1
+version:              1.3.2
 cabal-version:        >= 1.10
 tested-with:          GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
 license:              BSD3


### PR DESCRIPTION
There are two things worth noting here:

1. `ignoringAbsence` and `forgivingAbsence` cannot have their types relaxed since they take an `m` action as an argument.
2. Technically speaking, modification to the methods in the `AnyPath` class could cause breakage, and therefore this may deserve a major version bump. However, my understanding is that these instances are only defined internally, and therefore there is no external breakage. In any event, depending on how you feel, I see three choices here:
    1. Keep the changes as I wrote them here
    2. Roll back the changes to `AnyPath`
    3. Make this a major version bump instead