### PR TITLE
Fix `NotAProperPrefix` problem in `walkDirRel`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Path IO 1.4.1
+
+* Fixed a bug in `walkDirRel` that resulted in `NotAProperPrefix` exception
+  every time the function was called.
+
 ## Path IO 1.4.0
 
 * Added relative versions of some actions: `listDirRel`, `listDirRecurRel`,

--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -14,6 +14,7 @@
 
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE TypeFamilies      #-}
 
@@ -561,8 +562,9 @@ walkDirRel handler' topdir' = do
         stripDir topdir
 #endif
       handler curdir subdirs files = do
-        -- These should not ever fail.
-        curdirRel  <- stripTopdir curdir
+        curdirRel  <- if curdir == topdir
+          then return $(mkRelDir ".")
+          else stripTopdir curdir
         subdirsRel <- mapM stripTopdir subdirs
         filesRel   <- mapM stripTopdir files
         action     <- handler' curdirRel subdirsRel filesRel

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -36,6 +36,7 @@ main = hspec . around withSandbox $ do
   describe "getCurrentDir"    getCurrentDirSpec
   describe "setCurrentDir"    setCurrentDirSpec
   describe "withCurrentDir"   withCurrentDirSpec
+  describe "walkDirRel"       walkDirRelSpec
 #ifndef mingw32_HOST_OS
   -- NOTE We can't quite test this on Windows as well, because the
   -- environmental variables HOME and TMPDIR do not exist there.
@@ -159,6 +160,15 @@ withCurrentDirSpec = it "temporarily modifies current dir" $ \dir -> do
   withCurrentDir dir $
     getCurrentDir `shouldReturn` dir
   getCurrentDir `shouldNotReturn` dir
+
+walkDirRelSpec :: SpecWith (Path Abs Dir)
+walkDirRelSpec = it "does not throw exceptions" $ \dir -> do
+  let handler curdir subdirs files = do
+        curdir `shouldBe` $(mkRelDir ".")
+        subdirs `shouldBe` []
+        files `shouldBe` []
+        return WalkFinish
+  walkDirRel handler dir
 
 getHomeDirSpec :: SpecWith (Path Abs Dir)
 getHomeDirSpec =


### PR DESCRIPTION
For the directory where the traversal begins a `NotAProperPrefix` exception is thrown by `stripProperPrefix`. This happens when both arguments to `stripProperPrefix` are identical (i.e., when `curdir == topdir`). This commit treats the starting directory are a special case to avoid the exception.