### PR TITLE
copyDirRecurGen: don't follow any symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-## Unreleased
+## Path IO 1.6.0
+
+* Changed how `copyDirRecur` and `copyDirRecur'` functions work. Previously,
+  the functions created empty directories in the destination directory when
+  the source directory contained directory symlinks. The symlinked
+  directories were not recursively traversed. It also copied symlinked files
+  creating normal regular files in the target directory as the result. This
+  is fixed so that the function now behaves much like the `cp` utility, not
+  traversing symlinked directories, but recreating symlinks in the target
+  directory according to their targets in the source directory.
+
+* Fixed a bug in `createDirLink` which would always fail complaining that
+  its destination location does not exist.
 
 * Dropped support for GHC 8.2.
 

--- a/path-io.cabal
+++ b/path-io.cabal
@@ -56,6 +56,7 @@ test-suite tests
                     , directory    >= 1.3.2.0 && < 1.4
                     , exceptions   >= 0.8     && < 0.11
                     , hspec        >= 2.0     && < 3.0
+                    , filepath     >= 1.2     && < 1.5
                     , path         >= 0.6     && < 0.7
                     , path-io
                     , transformers >= 0.3     && < 0.6


### PR DESCRIPTION
In `copyDirRecurGen`, filter out all symlinks in the list of directories and files returned by `listDirRecur`.

Modified the assertions in the tests to ensure that symlinks are not considered when comparing the result of a `copyDirRecurGen`.

  Fixes: https://github.com/mrkkrp/path-io/issues/49