### PR TITLE
Switch to `Control.Monad.Trans.Writer.Strict`

### DIFF
--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -121,7 +121,7 @@ import Control.Monad.Catch
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
-import Control.Monad.Trans.Writer.Lazy (WriterT, execWriterT, tell)
+import Control.Monad.Trans.Writer.Strict (WriterT, execWriterT, tell)
 import qualified Data.DList as DList
 import Data.Either (lefts, rights)
 import Data.Kind (Type)


### PR DESCRIPTION
Close #55

When using `Control.Monad.Trans.Writer.Lazy`, references to every path
traversed are retained during the execution of `walkDirAccumWith`.
Switching to the strict version resolves this, and can dramatically
reduce memory consumption when traversing large directory trees..