### PR TITLE
Fix findFiles logic.

### DIFF
--- a/Path/IO.hs
+++ b/Path/IO.hs
@@ -1242,7 +1242,7 @@ findFilesWith ::
 findFilesWith _ [] _ = return []
 findFilesWith f (d : ds) file = do
   bfile <- (</> file) <$> makeAbsolute d
-  exist <- doesFileExist file
+  exist <- doesFileExist bfile
   b <- if exist then f bfile else return False
   if b
     then (bfile :) <$> findFilesWith f ds file


### PR DESCRIPTION
I faced the bug using findFiles. It list me `[bfile]` when `file` of interest not exist in any of `[dir]`